### PR TITLE
Fix branch in CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes the PR branch, which appears to `main` rather than `master`.

I believe this may highlight some failing tests because the workflow hasn't been running due to the branch name mismatch.